### PR TITLE
Token: added getter getOriginalUserId()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 In order to read more about upgrading and BC breaks have a look at the [UPGRADE Document](UPGRADE.md).
 
-## 1.2.2 (12. December 2021)
+## 1.3.0 (12. December 2021)
 
 + [#8](https://github.com/luyadev/luya-module-admin-usertoken/pull/8) Token: added getOriginalUserId() method, used in getUser() relation. Bootstrap: use originalUserId, instead of user_id.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 In order to read more about upgrading and BC breaks have a look at the [UPGRADE Document](UPGRADE.md).
 
+## 1.2.2 (12. December 2021)
+
++ [#8](https://github.com/luyadev/luya-module-admin-usertoken/pull/8) Token: added getOriginalUserId() method, used in getUser() relation. Bootstrap: use originalUserId, instead of user_id.
+
 ## 1.2.1 (27. July 2021)
 
 + Include version 4.0 of LUYA Admin module.

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -35,7 +35,7 @@ class Bootstrap implements BootstrapInterface
         $token = Token::find()->where(['token' => $event->token])->one();
 
         if ($token) {
-            $user = User::findOne($token->user_id);
+            $user = User::findOne($token->originalUserId);
             if ($user) {
                 $event->login($user);
 

--- a/src/models/Token.php
+++ b/src/models/Token.php
@@ -18,7 +18,6 @@ use yii\behaviors\TimestampBehavior;
  * @property integer $login_count
  * @property integer $created_at
  * @property integer $updated_at
- *
  * @property-read integer $originalUserId
  * 
  * @since 1.0.0
@@ -107,6 +106,10 @@ class Token extends NgRestModel
         ];
     }
     
+    /**
+     * @return string The user id before relation is populated
+     * @since 1.3.0
+     */
     public function getOriginalUserId()
     {
         return $this->getOldAttribute('user_id');

--- a/src/models/Token.php
+++ b/src/models/Token.php
@@ -18,6 +18,8 @@ use yii\behaviors\TimestampBehavior;
  * @property integer $login_count
  * @property integer $created_at
  * @property integer $updated_at
+ *
+ * @property-read integer $originalUserId
  * 
  * @since 1.0.0
  * @author Basil Suter <git@nadar.io>
@@ -104,7 +106,12 @@ class Token extends NgRestModel
             ['delete', false],
         ];
     }
-
+    
+    public function getOriginalUserId()
+    {
+        return $this->getOldAttribute('user_id');
+    }
+    
     /**
      * App Relation
      *
@@ -122,6 +129,6 @@ class Token extends NgRestModel
      */
     public function getUser()
     {
-        return $this->hasOne(User::class, ['id' => 'user_id']);
+        return $this->hasOne(User::class, ['id' => 'originalUserId']);
     }
 }


### PR DESCRIPTION
### What are you changing/introducing

Fixed #7 . 

Token: added getOriginalUserId() method, used in getUser() relation.
Bootstrap: use originalUserId, instead of user_id.


### What is the reason for changing/introducing

Able to use ?ngrestCallType=list

### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no info
| Fixed issues  | #7